### PR TITLE
feat: Spring AI 오라클 벡터 저장소 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,9 +20,16 @@ configurations {
     }
 }
 
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.ai:spring-ai-bom:2.0.0-M6"
+    }
+}
+
 repositories {
     mavenLocal()
     mavenCentral()
+    maven { url 'https://repo.spring.io/milestone' }
 }
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
@@ -43,6 +50,7 @@ dependencies {
 
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'com.oracle.database.jdbc:ojdbc11'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
@@ -67,6 +75,9 @@ dependencies {
 
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.7'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.7'
+
+    implementation 'org.springframework.ai:spring-ai-starter-model-openai'
+    implementation 'org.springframework.ai:spring-ai-starter-vector-store-oracle'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/raota/global/ai/OracleVectorProperties.java
+++ b/src/main/java/com/raota/global/ai/OracleVectorProperties.java
@@ -1,0 +1,18 @@
+package com.raota.global.ai;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.ai.oracle")
+public record OracleVectorProperties(
+        String url,
+        String username,
+        String password,
+        String driverClassName,
+        boolean initializeSchema,
+        String indexType,
+        String distanceType,
+        int dimensions,
+        boolean forcedNormalization,
+        boolean removeExistingVectorStoreTable,
+        int searchAccuracy
+) {}

--- a/src/main/java/com/raota/global/config/AiConfig.java
+++ b/src/main/java/com/raota/global/config/AiConfig.java
@@ -1,0 +1,57 @@
+package com.raota.global.config;
+
+import com.raota.global.ai.OracleVectorProperties;
+import com.zaxxer.hikari.HikariDataSource;
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.ai.vectorstore.oracle.OracleVectorStore;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@Configuration
+@EnableConfigurationProperties(OracleVectorProperties.class)
+public class AiConfig {
+
+    @Bean
+    public JdbcTemplate oracleVectorJdbcTemplate(OracleVectorProperties properties) {
+        var dataSource = new HikariDataSource();
+        dataSource.setJdbcUrl(properties.url());
+        dataSource.setUsername(properties.username());
+        dataSource.setPassword(properties.password());
+        dataSource.setDriverClassName(properties.driverClassName());
+        return new JdbcTemplate(dataSource);
+    }
+
+    @Bean
+    public VectorStore vectorStore(
+            JdbcTemplate oracleVectorJdbcTemplate,
+            EmbeddingModel embeddingModel,
+            OracleVectorProperties properties
+    ) {
+        return OracleVectorStore.builder(oracleVectorJdbcTemplate, embeddingModel)
+                .indexType(parseIndexType(properties.indexType()))
+                .distanceType(parseDistanceType(properties.distanceType()))
+                .dimensions(properties.dimensions())
+                .searchAccuracy(properties.searchAccuracy())
+                .initializeSchema(properties.initializeSchema())
+                .forcedNormalization(properties.forcedNormalization())
+                .removeExistingVectorStoreTable(properties.removeExistingVectorStoreTable())
+                .build();
+    }
+
+    private OracleVectorStore.OracleVectorStoreIndexType parseIndexType(String value) {
+        if (value == null || value.isBlank()) {
+            return OracleVectorStore.OracleVectorStoreIndexType.NONE;
+        }
+        return OracleVectorStore.OracleVectorStoreIndexType.valueOf(value.toUpperCase());
+    }
+
+    private OracleVectorStore.OracleVectorStoreDistanceType parseDistanceType(String value) {
+        if (value == null || value.isBlank()) {
+            return OracleVectorStore.OracleVectorStoreDistanceType.COSINE;
+        }
+        return OracleVectorStore.OracleVectorStoreDistanceType.valueOf(value.toUpperCase());
+    }
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -59,6 +59,15 @@ spring:
       host: ${SPRING_DATA_REDIS_HOST}
       port: ${SPRING_DATA_REDIS_PORT}
 
+  ai:
+    model:
+      embedding: openai
+    openai:
+      api-key: ${OPENAI_API_KEY}
+      embedding:
+        model: ${SPRING_AI_OPENAI_EMBEDDING_MODEL:text-embedding-3-small}
+        dimensions: ${SPRING_AI_OPENAI_EMBEDDING_DIMENSIONS:1536}
+
   jpa:
     hibernate:
       ddl-auto: validate
@@ -126,3 +135,16 @@ app:
         ramenShopList:
           ttl-seconds: ${APP_CACHE_RAMEN_SHOP_LIST_TTL_SECONDS:300}
           maximum-size: ${APP_CACHE_RAMEN_SHOP_LIST_MAX_SIZE:50}
+  ai:
+    oracle:
+      url: ${AI_ORACLE_DATASOURCE_URL}
+      username: ${AI_ORACLE_DATASOURCE_USERNAME}
+      password: ${AI_ORACLE_DATASOURCE_PASSWORD}
+      driver-class-name: ${AI_ORACLE_DRIVER_CLASS_NAME:oracle.jdbc.OracleDriver}
+      initialize-schema: ${AI_ORACLE_INITIALIZE_SCHEMA:false}
+      index-type: ${AI_ORACLE_INDEX_TYPE:NONE}
+      distance-type: ${AI_ORACLE_DISTANCE_TYPE:COSINE}
+      dimensions: ${AI_ORACLE_DIMENSIONS:1536}
+      forced-normalization: ${AI_ORACLE_FORCED_NORMALIZATION:false}
+      remove-existing-vector-store-table: ${AI_ORACLE_REMOVE_EXISTING_VECTOR_STORE_TABLE:false}
+      search-accuracy: ${AI_ORACLE_SEARCH_ACCURACY:95}

--- a/src/test/java/com/raota/integration/OracleVectorStoreSmokeTest.java
+++ b/src/test/java/com/raota/integration/OracleVectorStoreSmokeTest.java
@@ -1,0 +1,60 @@
+package com.raota.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("local")
+class OracleVectorStoreSmokeTest {
+
+    @Autowired
+    private VectorStore vectorStore;
+
+    @Test
+    void vector_store_add_and_search() {
+        String testRunId = UUID.randomUUID().toString();
+
+        List<Document> documents = List.of(
+                new Document(
+                        "테스트 런 " + testRunId + " - 진한 돈코츠 국물과 차슈가 강점인 라멘집",
+                        Map.of(
+                                "shopId", "1",
+                                "source", "TEST",
+                                "documentType", "PROFILE",
+                                "testRunId", testRunId
+                        )
+                ),
+                new Document(
+                        "테스트 런 " + testRunId + " - 깔끔한 쇼유 베이스와 가벼운 식사가 장점인 라멘집",
+                        Map.of(
+                                "shopId", "2",
+                                "source", "TEST",
+                                "documentType", "PROFILE",
+                                "testRunId", testRunId
+                        )
+                )
+        );
+
+        vectorStore.add(documents);
+
+        List<Document> results = vectorStore.similaritySearch("진한 국물 라멘 추천");
+
+        assertThat(results)
+                .isNotEmpty()
+                .extracting(Document::getText)
+                .anyMatch(text -> text.contains("돈코츠"));
+
+        assertThat(results)
+                .extracting(Document::getText)
+                .anyMatch(text -> text.contains(testRunId) && text.contains("돈코츠"));
+    }
+}


### PR DESCRIPTION
## 변경 사항
- Spring AI OpenAI/Oracle Vector Store 의존성 추가
- Oracle 벡터 저장소 설정 및 프로퍼티 바인딩 추가
- Oracle Vector Store 스모크 테스트 추가
- prod 설정용 AI/Oracle 환경변수 키 추가

## 검증
- ./gradlew test --tests com.raota.integration.OracleVectorStoreSmokeTest